### PR TITLE
refactor: change styles of the text input and export button

### DIFF
--- a/src/components/btn-save-palette/ButtonSavePalette.module.css
+++ b/src/components/btn-save-palette/ButtonSavePalette.module.css
@@ -1,7 +1,8 @@
 .btn_save_palette {
-    padding: 1rem;
+    padding: 1rem 1.5rem;
     border-radius: 0.5rem;
-    margin: 0.25rem;
+    margin-bottom: 0.25rem;
+    margin-top: 0.5rem;
     font-family: 'Playfair', serif;
     font-weight: 700;
     font-size: 1.0625rem;

--- a/src/components/input-color/input-color-text/InputColorText.module.css
+++ b/src/components/input-color/input-color-text/InputColorText.module.css
@@ -1,10 +1,16 @@
 .input_color_text {
-    border: 1px solid rgb(var(--clr-rgb-on-surface));
     font-size: 1.1rem;
     font-family: 'Open Sans', sans-serif;
     padding: 0.3125em;
     width: 10ch;
     border-radius: 5px;
-    color: rgb(var(--clr-input-text));
-    caret-color: rgb(var(--clr-input-text));
+    color: rgb(var(--clr-rgb-on-secd-cont));
+    caret-color: rgb(var(--clr-rgb-on-secd-cont));
+    background-color: rgba(var(--clr-rgb-secd-cont));
+    outline: none;
+    border: 2px solid rgba(var(--clr-rgb-on-surf-var) / 0.5);
+  }
+
+.input_color_text:focus {
+    border-color: rgb(var(--clr-rgb-secd));
   }

--- a/src/index.css
+++ b/src/index.css
@@ -97,8 +97,6 @@
   --clr-rgb-err-cont: var(--clr-rgb-e-90);
   --clr-rgb-on-err: var(--clr-rgb-e-99);
   --clr-rgb-on-err-cont: var(--clr-rgb-e-10);
-
-  --clr-input-text: 0 0 0;
 }
 
 html.dark {
@@ -139,8 +137,6 @@ html.dark {
   --clr-rgb-err-cont: var(--clr-rgb-e-30);
   --clr-rgb-on-err: var(--clr-rgb-e-20);
   --clr-rgb-on-err-cont: var(--clr-rgb-e-90);
-
-  --clr-input-text: 255 255 255;
 }
 
 html {

--- a/src/layouts/section-input-color/SectionInputColor.module.css
+++ b/src/layouts/section-input-color/SectionInputColor.module.css
@@ -14,7 +14,7 @@
 
 .color_inputs {
     display: flex;
-    gap: 2rem;
+    gap: 1.5rem;
     justify-content: center;
     align-items: center;
     text-align: center;


### PR DESCRIPTION
1. Изменен стиль поля ввода цвета
2. Увеличены ширина и отступы для кнопки сохранения палитры
3. Удален цвет `--clr-input-text` (уже не используется)